### PR TITLE
fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: CI
+name: Release
 
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build_and_push_docker_image:


### PR DESCRIPTION
If I understand https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release correctly also if you directly create + publish the publish one should be triggered.